### PR TITLE
Fix __iob symbol handling

### DIFF
--- a/[SRC]Client/compat_stdio.cpp
+++ b/[SRC]Client/compat_stdio.cpp
@@ -2,8 +2,12 @@
 #include <stdio.h>
 
 // Provide the deprecated __iob symbol used by older libraries
+#if _MSC_VER >= 1400
+extern "C" FILE* __imp___iob_func = __acrt_iob_func(0);
+#else
 extern "C" FILE _iob[] = { *stdin, *stdout, *stderr };
 extern "C" FILE* __imp___iob = _iob;
+#endif
 
 // Map legacy import variables for common stdio routines
 extern "C" int (__cdecl* __imp__printf)(const char*, ...)   = &printf;


### PR DESCRIPTION
## Summary
- fix `_iob` compatibility for newer MSVC versions

## Testing
- `ctest` *(fails: No test configuration file found)*

------
https://chatgpt.com/codex/tasks/task_e_6850438aa9ec832b93e6a23b74b1c299