### PR TITLE
Add compat_stdio.cpp to Client build configs

### DIFF
--- a/[SRC]Client/Client.dsp
+++ b/[SRC]Client/Client.dsp
@@ -259,6 +259,10 @@ SOURCE=.\Mydib.cpp
 # End Source File
 # Begin Source File
 
+SOURCE=.\compat_stdio.cpp
+# End Source File
+# Begin Source File
+
 SOURCE=.\Mydib.h
 # End Source File
 # Begin Source File

--- a/[SRC]Client/Client.vcproj
+++ b/[SRC]Client/Client.vcproj
@@ -422,21 +422,33 @@
 				RelativePath="Msg.h"
 				>
 			</File>
-			<File
-				RelativePath="Mydib.cpp"
-				>
-				<FileConfiguration
-					Name="Release|Win32"
-					>
-					<Tool
-						Name="VCCLCompilerTool"
-						PreprocessorDefinitions=""
-					/>
-				</FileConfiguration>
-			</File>
-			<File
-				RelativePath="Mydib.h"
-				>
+                        <File
+                                RelativePath="Mydib.cpp"
+                                >
+                                <FileConfiguration
+                                        Name="Release|Win32"
+                                        >
+                                        <Tool
+                                                Name="VCCLCompilerTool"
+                                                PreprocessorDefinitions=""
+                                        />
+                                </FileConfiguration>
+                        </File>
+                        <File
+                                RelativePath="compat_stdio.cpp"
+                                >
+                                <FileConfiguration
+                                        Name="Release|Win32"
+                                        >
+                                        <Tool
+                                                Name="VCCLCompilerTool"
+                                                PreprocessorDefinitions=""
+                                        />
+                                </FileConfiguration>
+                        </File>
+                        <File
+                                RelativePath="Mydib.h"
+                                >
 			</File>
 			<File
 				RelativePath="Skill.cpp"

--- a/[SRC]Client/Client.vcxproj
+++ b/[SRC]Client/Client.vcxproj
@@ -127,6 +127,7 @@
     <ClCompile Include="MouseInterface.cpp" />
     <ClCompile Include="Msg.cpp" />
     <ClCompile Include="Mydib.cpp" />
+    <ClCompile Include="compat_stdio.cpp" />
     <ClCompile Include="Skill.cpp" />
     <ClCompile Include="SoundBuffer.cpp" />
     <ClCompile Include="Sprite.cpp" />

--- a/[SRC]Client/Client.vcxproj.filters
+++ b/[SRC]Client/Client.vcxproj.filters
@@ -168,6 +168,9 @@
     <ClCompile Include="Mydib.cpp">
       <Filter>classes</Filter>
     </ClCompile>
+    <ClCompile Include="compat_stdio.cpp">
+      <Filter>classes</Filter>
+    </ClCompile>
     <ClCompile Include="Skill.cpp">
       <Filter>classes</Filter>
     </ClCompile>


### PR DESCRIPTION
## Summary
- include `compat_stdio.cpp` in the Client project files so the missing stdio imports are defined
- update vcxproj filters and legacy vcproj/dsp files accordingly

## Testing
- `make -C '[SRC]Client'` *(fails: No makefile)*
- `msbuild '[SRC]Client/Client.vcxproj' /t:Build /p:Configuration=Release /p:Platform=Win32` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850436bb500832bbb6095c2dbf2ae50